### PR TITLE
Add responsive layout and dark mode

### DIFF
--- a/public/color.html
+++ b/public/color.html
@@ -4,10 +4,13 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Color Game - Nerd Corner</title>
+    <script src="/js/UX/theme_init.js"></script>
+    <link rel="stylesheet" href="css/base.css">
     <link rel="stylesheet" href="css/color.css">
     <link rel="icon" href="assets/icon.png" sizes="32x32" type="image/png" />
 </head>
 <body>
+    <button id="theme-toggle" class="theme-toggle">🌓</button>
     <div class="game-container">
         <div class="header">
             <h1>Color Game</h1>
@@ -52,5 +55,6 @@
 
     <script src="/js/utils/api.js"></script>
     <script src="/js/color/color.js"></script>
+    <script src="/js/UX/theme.js" defer></script>
 </body>
-</html> 
+</html>

--- a/public/css/base.css
+++ b/public/css/base.css
@@ -225,3 +225,15 @@ h3 {
 #create-company-btn {
   margin-top: auto;
 }
+
+.theme-toggle {
+  position: fixed;
+  top: 1rem;
+  right: 1rem;
+  background: transparent;
+  border: none;
+  font-size: 1.5rem;
+  cursor: pointer;
+  color: var(--text);
+  z-index: 1000;
+}

--- a/public/css/color.css
+++ b/public/css/color.css
@@ -1,3 +1,5 @@
+@import url('base.css');
+
 * {
     margin: 0;
     padding: 0;
@@ -6,7 +8,7 @@
 
 body {
     font-family: Arial, sans-serif;
-    background-color: #f0f0f0;
+    background-color: var(--bg);
     min-height: 100vh;
     display: flex;
     justify-content: center;
@@ -15,7 +17,7 @@ body {
 }
 
 .game-container {
-    background-color: white;
+    background-color: var(--card-bg);
     border-radius: 10px;
     padding: 2rem;
     box-shadow: 0 0 20px rgba(0, 0, 0, 0.1);
@@ -65,7 +67,7 @@ body {
 #hexInput {
     padding: 0.8rem;
     font-size: 1.2rem;
-    border: 2px solid #ddd;
+    border: 2px solid var(--border);
     border-radius: 5px;
     width: 150px;
     text-align: center;
@@ -74,7 +76,7 @@ body {
 
 #hexInput:focus {
     outline: none;
-    border-color: #4CAF50;
+    border-color: var(--primary);
     box-shadow: 0 0 5px rgba(76, 175, 80, 0.3);
 }
 
@@ -86,8 +88,8 @@ body {
 .btn {
     padding: 0.8rem 2rem;
     font-size: 1.1rem;
-    background-color: #4CAF50;
-    color: white;
+    background-color: var(--primary);
+    color: var(--card-bg);
     border: none;
     border-radius: 5px;
     cursor: pointer;
@@ -106,12 +108,12 @@ body {
 .instructions {
     margin-top: 2rem;
     padding-top: 2rem;
-    border-top: 1px solid #ddd;
+    border-top: 1px solid var(--border);
 }
 
 .instructions h2 {
     margin-bottom: 1rem;
-    color: #333;
+    color: var(--text);
 }
 
 .instructions p {
@@ -124,4 +126,14 @@ body {
     color: #888;
     font-size: 0.9rem;
     margin-top: 1rem;
-} 
+}
+
+@media (max-width: 480px) {
+    .game-container {
+        padding: 1rem;
+    }
+    .target-color {
+        width: 150px;
+        height: 150px;
+    }
+}

--- a/public/css/index.css
+++ b/public/css/index.css
@@ -1,13 +1,7 @@
+@import url('base.css');
+
 :root {
-  --bg: #ffffff;
-  --card-bg: #ffffff;
-  --primary: #3366ff;
-  --text: #333333;
-  --subtext: #9d9999;
-  --border: #e0e0e0;
-  --radius: 8px;
   --radiuscard: 15px;
-  --shadow: rgba(0, 0, 0, 0.1);
 }
 
 * {
@@ -176,4 +170,16 @@ body {
 }
 .emoji-nerd:hover .nerd-hand {
   margin-top: 0.5rem;
+}
+
+@media (max-width: 480px) {
+  .login-card {
+    padding: 30px 20px;
+  }
+  .nerd-face {
+    font-size: 3rem;
+  }
+  .nerd-hand {
+    margin-left: -2rem;
+  }
 }

--- a/public/css/menu.css
+++ b/public/css/menu.css
@@ -1,9 +1,11 @@
+    @import url('base.css');
+
     /* Reset & base */
     * { margin: 0; padding: 0; box-sizing: border-box; }
     body {
       font-family: 'Arial', sans-serif;
-      background-color: #fafafa;
-      color: #333;
+      background-color: var(--bg);
+      color: var(--text);
       line-height: 1.4;
     }
     a { text-decoration: none; color: inherit; }
@@ -15,8 +17,8 @@
       align-items: center;
       justify-content: space-between;
       padding: 0.5rem 2rem;
-      background-color: #fff;
-      box-shadow: 0 2px 4px rgba(0,0,0,0.05);
+      background-color: var(--card-bg);
+      box-shadow: 0 2px 4px var(--shadow);
     }
     .logo {
       display: flex;
@@ -70,28 +72,28 @@
       align-items: center;
       font-size: 0.9rem;
     }
-    .nav-links a { color: #555; padding: 0.25rem 0.5rem; border-radius: 4px; }
-    .nav-links a.sign-up { color: #6c63ff; font-weight: bold; }
+    .nav-links a { color: var(--text); padding: 0.25rem 0.5rem; border-radius: 4px; }
+    .nav-links a.sign-up { color: var(--primary); font-weight: bold; }
     .nav-links a.dashboard {
-      background: #6c63ff;
-      color: #fff;
+      background: var(--primary);
+      color: var(--card-bg);
       font-weight: bold;
     }
     .nav-links select {
       padding: 0.25rem;
-      border: 1px solid #ddd;
+      border: 1px solid var(--border);
       border-radius: 4px;
-      background-color: #fff;
+      background-color: var(--card-bg);
       font-size: 0.9rem;
     }
-    .btn { background: #6c63ff; color:#fff; padding:0.25rem 0.75rem; border-radius:4px; }
+    .btn { background: var(--primary); color: var(--card-bg); padding:0.25rem 0.75rem; border-radius:4px; }
     .btn:hover { opacity:0.9; }
-    .join-btn { 
-      background: #ffffff; 
-      color:#000000; 
-      padding:0.75rem 2rem; 
-      border: 2px solid black;
-      border-radius:4px; 
+    .join-btn {
+      background: var(--card-bg);
+      color: var(--text);
+      padding:0.75rem 2rem;
+      border: 2px solid var(--text);
+      border-radius:4px;
     }
     /* Main content */
     main {
@@ -132,7 +134,7 @@
       color: #888;
       margin-bottom: 40px;
     }
-    hr { border: none; border-top: 1px solid #e0e0e0; margin: 2rem 0; }
+    hr { border: none; border-top: 1px solid var(--border); margin: 2rem 0; }
 
     /* Cards */
     .cards {
@@ -142,10 +144,10 @@
       flex-wrap: wrap;
     }
     .card {
-      background-color: #fff;
+      background-color: var(--card-bg);
       width: 280px;
       border-radius: 8px;
-      box-shadow: 0 2px 6px rgba(0,0,0,0.1);
+      box-shadow: 0 2px 6px var(--shadow);
       overflow: hidden;
       display: flex;
       flex-direction: column;
@@ -154,7 +156,7 @@
     .card img {
       width: 100%; height: 160px; object-fit: cover; background-color: #000;
     }
-    .card .label { padding: 1rem; font-size: 1.2rem; color: #222; text-align: left; flex-grow: 1; }
+    .card .label { padding: 1rem; font-size: 1.2rem; color: var(--text); text-align: left; flex-grow: 1; }
 
     /* Skeleton loader */
     .skeleton {
@@ -198,5 +200,25 @@
 
     .card:hover {
       transform: translateY(-5px);
-      box-shadow: 0 5px 15px rgba(0,0,0,0.2);
+      box-shadow: 0 5px 15px var(--shadow);
+    }
+
+    @media (max-width: 600px) {
+      header {
+        flex-direction: column;
+        align-items: flex-start;
+      }
+      .nav-links {
+        flex-wrap: wrap;
+        gap: 0.5rem;
+        margin-top: 0.5rem;
+      }
+      .cards {
+        flex-direction: column;
+        align-items: center;
+      }
+      .card {
+        width: 100%;
+        max-width: 300px;
+      }
     }

--- a/public/css/pong.css
+++ b/public/css/pong.css
@@ -1,11 +1,13 @@
+@import url('base.css');
+
 body {
     margin: 0;
     height: 100vh;
     display: flex;
     justify-content: center;
     align-items: center;
-    background: #111;
-    color: #fff;
+    background: var(--bg);
+    color: var(--text);
     font-family: sans-serif;
     position: relative; /* pour l'overlay */
   }
@@ -13,7 +15,7 @@ body {
   /* Canvas */
   #gameCanvas {
     background: #000;
-    border: 2px solid #fff;
+    border: 2px solid var(--text);
     z-index: 1;
   }
   
@@ -34,7 +36,7 @@ body {
   #popup {
     background: #222;
     padding: 20px 30px;
-    border: 2px solid #fff;
+    border: 2px solid var(--text);
     border-radius: 8px;
     text-align: center;
   }
@@ -53,12 +55,22 @@ body {
     padding: 10px 20px;
     font-size: 16px;
     cursor: pointer;
-    background: #fff;
-    color: #000;
-    border: none;
+    background: var(--card-bg);
+    color: var(--text);
+    border: 1px solid var(--border);
     border-radius: 4px;
   }
   #startBtn:hover {
     opacity: 0.9;
+  }
+
+  @media (max-width: 600px) {
+    #gameCanvas {
+      width: 100%;
+      height: auto;
+    }
+    #popup h1 {
+      font-size: 24px;
+    }
   }
   

--- a/public/css/signup.css
+++ b/public/css/signup.css
@@ -1,13 +1,4 @@
-:root {
-  --bg: #f5f7fa;
-  --card-bg: #ffffff;
-  --primary: #3366ff;
-  --text: #333333;
-  --subtext: #666666;
-  --border: #e0e0e0;
-  --radius: 8px;
-  --shadow: rgba(0, 0, 0, 0.1);
-}
+@import url('base.css');
 * { box-sizing: border-box; margin: 0; padding: 0; }
 body {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
@@ -113,4 +104,16 @@ body {
 }
 .emoji-nerd:hover .nerd-hand {
   margin-top: 0.5rem;
+}
+
+@media (max-width: 480px) {
+  .login-card {
+    padding: 30px 20px;
+  }
+  .nerd-face {
+    font-size: 3rem;
+  }
+  .nerd-hand {
+    margin-left: -2rem;
+  }
 }

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -15,6 +15,7 @@
   <script type="module" src="/js/UX/toast.js" defer></script>
 </head>
 <body>
+  <button id="theme-toggle" class="theme-toggle">🌓</button>
   <div class="wallet-wrapper">
     <header class="wallet" id="wallet">
       <span class="wallet-company">Entreprise : <span id="company-text"></span></span>
@@ -145,9 +146,9 @@
   <script type="module" src="/js/dashboard/main.js" defer></script>
   <script src="/socket.io/socket.io.js"></script>
   <script src="/js/chat/chat.js" defer></script>
-  <!-- <script src="/js/theme.js" defer></script>-->
   <script src="/js/UX/scroll.js" defer></script>
-    <!-- Footer -->
+  <script src="/js/UX/theme.js" defer></script>
+  <!-- Footer -->
   <footer class="site-footer">
     <div class="footer-content">
       <small>

--- a/public/forgot-password.html
+++ b/public/forgot-password.html
@@ -1,5 +1,7 @@
 <center><h1>Fallait le retenir xd</h1></center>
 <link rel="icon" href="assets/icon.png" sizes="32x32" type="image/png">
+<script src="/js/UX/theme_init.js"></script>
+<link rel="stylesheet" href="css/base.css">
 <style>
 body {
     font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
@@ -13,3 +15,5 @@ h1 {
     color: #333333;
 }
 </style>
+<button id="theme-toggle" class="theme-toggle">🌓</button>
+<script src="/js/UX/theme.js" defer></script>

--- a/public/index.html
+++ b/public/index.html
@@ -5,11 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Connexion - NerdSociety</title>
   <script src="/js/UX/theme_init.js"></script>
+  <link rel="stylesheet" href="css/base.css" type="text/css">
   <link rel="stylesheet" href="css/index.css" type="text/css">
   <link rel="icon" href="assets/icon.png" sizes="32x32" type="image/png">
   <script src="https://cdn.jsdelivr.net/npm/pixi.js@8.9.2/dist/pixi.min.js"></script>
 </head>
 <body>
+  <button id="theme-toggle" class="theme-toggle">🌓</button>
   <canvas id="candlestick-bg"></canvas>
   <div class="login-card">
     <center><div class="emoji-nerd" role="img" aria-label="Nerd qui pointe le doigt">
@@ -41,5 +43,6 @@
   </div>
   <p class="credit">made and maintained by chatgpt</p>
   <script src="/js/signin/index.js"></script>
+  <script src="/js/UX/theme.js" defer></script>
 </body>
 </html>

--- a/public/menu.html
+++ b/public/menu.html
@@ -5,6 +5,8 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>Nerd Corner</title>
+  <script src="/js/UX/theme_init.js"></script>
+  <link rel="stylesheet" href="css/base.css" type="text/css" />
   <link rel="stylesheet" href="css/menu.css" type="text/css" />
   <link rel="icon" href="assets/icon.png" sizes="32x32" type="image/png" />
   <!-- Préchargement des ressources critiques -->
@@ -33,6 +35,7 @@
         <option value="fr">French</option>
         <option value="en">English</option>
       </select>
+      <button id="theme-toggle" class="theme-toggle">🌓</button>
     </nav>
   </header>
 
@@ -70,5 +73,6 @@
       </div>
     </div>
   </main>
+  <script src="/js/UX/theme.js" defer></script>
 </body>
 </html>

--- a/public/pong.html
+++ b/public/pong.html
@@ -4,10 +4,13 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Gnop</title>
+  <script src="/js/UX/theme_init.js"></script>
+  <link rel="stylesheet" href="css/base.css">
   <link rel="stylesheet" href="css/pong.css">
   <link rel="icon" href="assets/icon.png" sizes="32x32" type="image/png">
 </head>
 <body>
+  <button id="theme-toggle" class="theme-toggle">🌓</button>
   <!-- Popup de démarrage -->
   <div id="overlay">
     <div id="popup">
@@ -19,5 +22,6 @@
   <canvas id="gameCanvas" width="800" height="400"></canvas>
   <script src="/js/utils/api.js" defer></script>
   <script src="js/game/pong.js"></script>
+  <script src="/js/UX/theme.js" defer></script>
 </body>
 </html>

--- a/public/profile.html
+++ b/public/profile.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Profil - ClickSociety</title>
   <script src="/js/UX/theme_init.js"></script>
+  <link rel="stylesheet" href="css/base.css" type="text/css">
   <link rel="stylesheet" href="css/profile.css" type="text/css">
   <link rel="icon" href="assets/icon.png" sizes="32x32" type="image/png">
   <!-- Chart.js CDN -->

--- a/public/signup.html
+++ b/public/signup.html
@@ -5,10 +5,12 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Créer un compte - ClickSociety</title>
   <script src="/js/UX/theme_init.js"></script>
+  <link rel="stylesheet" href="css/base.css" type="text/css">
   <link rel="stylesheet" href="css/index.css" type="text/css">
   <link rel="icon" href="assets/icon.png" sizes="32x32" type="image/png">
 </head>
 <body>
+  <button id="theme-toggle" class="theme-toggle">🌓</button>
   <canvas id="candlestick-bg"></canvas>
   <div class="login-card">
     <center><div class="emoji-nerd" role="img" aria-label="Nerd qui pointe le doigt">
@@ -39,5 +41,6 @@
   </div>
   <p class="credit">made and maintained by spectra</p>
   <script src="/js/signup/signup.js"></script>
+  <script src="/js/UX/theme.js" defer></script>
 </body>
 </html>

--- a/public/snake.html
+++ b/public/snake.html
@@ -4,6 +4,8 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" href="assets/icon.png" sizes="32x32" type="image/png">
+  <script src="/js/UX/theme_init.js"></script>
+  <link rel="stylesheet" href="css/base.css">
   <title>Snake Glitchy</title>
   <style>
     /* Styles de base */
@@ -87,6 +89,7 @@
   </style>
 </head>
 <body>
+  <button id="theme-toggle" class="theme-toggle">🌓</button>
   <div id="title">Snake</div>
   <div id="game-wrapper">
     <canvas id="game" width="400" height="400"></canvas>
@@ -114,5 +117,6 @@
   </div>
   <script src="/js/utils/api.js" defer></script>
   <script src="/js/game/snake.js"></script>
+  <script src="/js/UX/theme.js" defer></script>
 </body>
 </html>

--- a/public/trade.html
+++ b/public/trade.html
@@ -17,6 +17,7 @@
   <link rel="stylesheet" href="/css/chat.css">
 </head>
 <body>
+  <button id="theme-toggle" class="theme-toggle">🌓</button>
   <div class="container">
     <!-- HEADER STICKY -->
     <header class="header">
@@ -106,5 +107,6 @@
   <script type="module" src="/js/trade/main.js" defer></script>
   <script src="/socket.io/socket.io.js"></script>
   <script src="/js/chat/chat.js" defer></script>
+  <script src="/js/UX/theme.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- import global base styles on all pages
- implement dark mode toggle with new `.theme-toggle` button
- update several CSS files to use theme variables and add mobile breakpoints
- include theme initialization and script on every HTML page

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684c4c0444e4832881f8d7ed32a737eb